### PR TITLE
el8 / el9 build script + remove fedora 38 rpm generation

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ set -e
 # delete any existing rpms
 rm -f nushell-*.rpm
 
-for release in {38..40}; do
+for release in {39..41}; do
   docker run --rm -it -v $(pwd):/code fedora:${release} /code/fedora.sh
 done
 

--- a/build.sh
+++ b/build.sh
@@ -8,3 +8,6 @@ for release in {39..41}; do
   docker run --rm -it -v $(pwd):/code fedora:${release} /code/fedora.sh
 done
 
+for release in {8..9}; do
+  docker run --rm -it -v $(pwd):/code rockylinux/rockylinux:${release} /code/rocky/build.sh
+done

--- a/create_nushell_package.nu
+++ b/create_nushell_package.nu
@@ -69,42 +69,45 @@ def create_rpm [ iter: string, op_type: string ] {
   echo "Done."
 }
 
-def main [ platform: string ] {
-  mut iter = ""
-  mut op_type = ""
-  match $platform {
-    'fc38' => {
-      $iter = $"1.($platform)"
-      $op_type = "rpm"
-    }
-    'fc39' => {
-      $iter = $"1.($platform)"
-      $op_type = "rpm"
-    }
-    'fc40' => {
-      $iter = $"1.($platform)"
-      $op_type = "rpm"
-    }
-    'el8' => {
-      $iter = $"1.($platform)"
-      $op_type = "rpm"
-    }
-    'el9' => {
-      $iter = $"1.($platform)"
-      $op_type = "rpm"
-    }
-    'bookworm' => {
-      $iter = $"1.($platform)"
-      $op_type = "deb"
-    }
-    'trixie' => {
-      $iter = $"1.($platform)"
-      $op_type = "deb"
-    }
-    _ => {
-      error make {msg: $"Invalid platform '($platform)' given!"}
-    }
-  }
+def main [ platform: string, pkg_type: string ] {
+  # mut iter = ""
+  # mut op_type = ""
+  # match $platform {
+  #   'fc38' => {
+  #     $iter = $"1.($platform)"
+  #     $op_type = "rpm"
+  #   }
+  #   'fc39' => {
+  #     $iter = $"1.($platform)"
+  #     $op_type = "rpm"
+  #   }
+  #   'fc40' => {
+  #     $iter = $"1.($platform)"
+  #     $op_type = "rpm"
+  #   }
+  #   'el8' => {
+  #     $iter = $"1.($platform)"
+  #     $op_type = "rpm"
+  #   }
+  #   'el9' => {
+  #     $iter = $"1.($platform)"
+  #     $op_type = "rpm"
+  #   }
+  #   'bookworm' => {
+  #     $iter = $"1.($platform)"
+  #     $op_type = "deb"
+  #   }
+  #   'trixie' => {
+  #     $iter = $"1.($platform)"
+  #     $op_type = "deb"
+  #   }
+  #   _ => {
+  #     error make {msg: $"Invalid platform '($platform)' given!"}
+  #   }
+  # }
+
+  let iter = $"1.($platform)"
+  let op_type = $pkg_type
 
   create_bundle_dir
   create_rpm $iter $op_type

--- a/create_nushell_package.nu
+++ b/create_nushell_package.nu
@@ -2,19 +2,20 @@
 # This program prepares the nushell rpm
 
 def get_pkg_info [] -> record {
-    return {
-      bin: "nu"
-      name: "nushell"
-      arch: "x86_64"
-      version: (~/.cargo/bin/nu --version)
-      vendor: "The Nushell Project Developers"
-      desc: "The nushell language and shell."
-      category: "nushell"
-      url: "https://www.nushell.sh/"
-      maintainer: "www.nushell.sh"
-      license: "MIT License"
-      dir: "build"
-    }
+  let nu_ver = run-external $"($env.HOME)/.cargo/bin/nu" ...["--version"]
+  return {
+    bin: "nu"
+    name: "nushell"
+    arch: "x86_64"
+    version: $nu_ver
+    vendor: "The Nushell Project Developers"
+    desc: "The nushell language and shell."
+    category: "nushell"
+    url: "https://www.nushell.sh/"
+    maintainer: "www.nushell.sh"
+    license: "MIT License"
+    dir: "build"
+  }
 }
 
 def create_bundle_dir [] {

--- a/fedora.sh
+++ b/fedora.sh
@@ -17,7 +17,7 @@ export PATH=$HOME/.cargo/bin:$PATH
 # cargo         - package manager for rust
 # openssl-devel - you know what this is
 
-dnf install -y wget rubygems rpm-build rust cargo openssl-devel
+dnf install -y wget rubygems ruby-devel rpm-build rust cargo openssl-devel
 
 # install fpm which is used to generate the rpm
 gem install fpm
@@ -32,5 +32,5 @@ strip ~/.cargo/bin/nu
 platform=$(cat /etc/os-release | grep VERSION_ID | cut -d "=" -f2)
 
 # run the rpm generation script with the installed version of nu
-nu create_nushell_package.nu "fc${platform}"
+nu create_nushell_package.nu "fc${platform}" "rpm"
 

--- a/fedora.sh
+++ b/fedora.sh
@@ -26,7 +26,7 @@ gem install fpm
 cargo install nu
 
 # strip the binary
-strip ~/.cargo/bin/nu
+strip ${HOME}/.cargo/bin/nu
 
 # get the fedora release number
 platform=$(cat /etc/os-release | grep VERSION_ID | cut -d "=" -f2)

--- a/rocky/Gemfile
+++ b/rocky/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'fpm'

--- a/rocky/Gemfile.lock
+++ b/rocky/Gemfile.lock
@@ -1,0 +1,36 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    arr-pm (0.0.12)
+    backports (3.24.1)
+    cabin (0.9.0)
+    clamp (1.0.1)
+    dotenv (2.8.1)
+    fpm (1.15.1)
+      arr-pm (~> 0.0.11)
+      backports (>= 2.6.2)
+      cabin (>= 0.6.0)
+      clamp (~> 1.0.0)
+      pleaserun (~> 0.0.29)
+      rexml
+      stud
+    insist (1.0.0)
+    mustache (0.99.8)
+    pleaserun (0.0.32)
+      cabin (> 0)
+      clamp
+      dotenv
+      insist
+      mustache (= 0.99.8)
+      stud
+    rexml (3.2.6)
+    stud (0.0.23)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  fpm
+
+BUNDLED WITH
+   1.16.1

--- a/rocky/build.sh
+++ b/rocky/build.sh
@@ -37,7 +37,7 @@ cargo install nu
 # strip the binary
 strip ${HOME}/.cargo/bin/nu
 
-# get the fedora release number
+# get the rockylinux release number
 platform=$(cat /etc/os-release | grep PLATFORM_ID | cut -d "=" -f2 | cut -d ":" -f2)
 
 # run the rpm generation script with the installed version of nu

--- a/rocky/build.sh
+++ b/rocky/build.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# mount the directory with create_nushell_package.nu script into /code
+# when starting the docker container
+
+set -e
+
+cd /code
+
+# cargo places built binaries at $HOME/.cargo/bin.
+# add the location to PATH env variable
+export PATH=$HOME/.cargo/bin:$PATH
+
+# wget          - to fetch license and other details
+# rubygems      - provides the gem command used to install fpm
+# ruby-devel    - ruby headers when required to compile ruby gems
+# rpm-build     - provides tools required to generate rpm
+# openssl-devel - you know what this is
+# make          - to run make targets
+# gcc           - gnu compiler
+
+dnf install -y wget rubygems ruby-devel rpm-build openssl-devel make gcc
+
+# install fpm which is used to generate the rpm
+gem install --file /code/rocky/Gemfile --no-lock
+
+# install latest rust & cargo via rustup
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs -o "${HOME}/rustup-init.sh"
+chmod +x /root/rustup-init.sh
+/root/rustup-init.sh -y
+
+# sourcing rust env
+source "${HOME}/.cargo/env"
+
+# install latest version of nu using cargo
+cargo install nu
+
+# strip the binary
+strip ~/.cargo/bin/nu
+
+# get the fedora release number
+platform=$(cat /etc/os-release | grep PLATFORM_ID | cut -d "=" -f2 | cut -d ":" -f2)
+
+# run the rpm generation script with the installed version of nu
+nu create_nushell_package.nu "${platform:0:3}" "rpm"
+

--- a/rocky/build.sh
+++ b/rocky/build.sh
@@ -35,7 +35,7 @@ source "${HOME}/.cargo/env"
 cargo install nu
 
 # strip the binary
-strip ~/.cargo/bin/nu
+strip ${HOME}/.cargo/bin/nu
 
 # get the fedora release number
 platform=$(cat /etc/os-release | grep PLATFORM_ID | cut -d "=" -f2 | cut -d ":" -f2)


### PR DESCRIPTION
* remove EOL'd fc38 from rpm generation.
* generate rpm for el8 & el9 based on RockyLinux
* remove platform validation from the `create_nushell_package.nu`.
* need to think a better way of handling the platforms without requiring code changes.