### PR TITLE
fix for stricter command signature parsing & remove fc39 & include fc41

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,7 @@ echo "deleting existing packages if any..."
 rm -f *.rpm *.deb
 
 # Fedora
-for release in {39..40}; do
+for release in {40..41}; do
   docker run --rm -it -v $(pwd):/code fedora:${release} /code/create_nushell_package.sh
 done
 

--- a/create_nushell_package.nu
+++ b/create_nushell_package.nu
@@ -1,7 +1,7 @@
 #!/usr/bin/env nu
 # This program prepares the nushell package
 
-def get_pkg_info []: -> record {
+def get_pkg_info []: nothing -> record {
   let nu_ver = run-external $"($env.HOME)/.cargo/bin/nu" ...["--version"]
   return {
     bin: "nu"

--- a/create_nushell_package.nu
+++ b/create_nushell_package.nu
@@ -1,7 +1,7 @@
 #!/usr/bin/env nu
 # This program prepares the nushell package
 
-def get_pkg_info [] -> record {
+def get_pkg_info []: -> record {
   let nu_ver = run-external $"($env.HOME)/.cargo/bin/nu" ...["--version"]
   return {
     bin: "nu"


### PR DESCRIPTION
Changes:

- nushell 101 brings stricter command signature parsing. This includes changes to address that.
- Removed Fedora Linux 39 Packaging
- Included Fedora Linux 41 Packaging

https://www.nushell.sh/blog/2024-12-24-nushell_0_101_0.html#stricter-command-signature-parsing-toc

